### PR TITLE
SM-928: adaptation of qtNats and refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,67 +1,49 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(QtNatsProject)
-
-include(CMakePrintHelpers)
-include(FetchContent)
-include(GenerateExportHeader)
+project(QtNats VERSION 0.1.0)
 
 option(BUILD_QMLNATS "Build the QML NATS plugin (Qt6-only)" OFF)
+option(BUILD_TESTING "Build unit tests" OFF)
 
 set(default_build_type "Release")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_INCLUDE_CURRENT_DIR ON)  # to find qtnats_export.h
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-# according to https://gitlab.kitware.com/cmake/cmake/-/issues/20843 I need 2 find_package's to detect Qt5/Qt6
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Test Qml Quick REQUIRED)
-message("Using Qt version ${QT_VERSION}")
 
-# show that we're git-cloning cnats
-set(FETCHCONTENT_QUIET FALSE)
-FetchContent_Declare(
-  cnats
-  GIT_REPOSITORY https://github.com/nats-io/nats.c.git
-  GIT_TAG        v3.3.0
-  GIT_SHALLOW    ON
-)
-
-set(NATS_BUILD_WITH_TLS OFF)
-set(NATS_BUILD_EXAMPLES OFF)
-set(NATS_BUILD_STREAMING OFF)
-set(NATS_BUILD_LIB_SHARED OFF)
-
-set(BUILD_TESTING OFF)  # do not build cnats tests
-
-FetchContent_MakeAvailable(cnats)
-
-include_directories(${cnats_SOURCE_DIR}/src src)
-
-# ------------- qtnats library ----------------------
 file(GLOB SOURCES "src/*.cpp")
 file(GLOB HEADERS "src/*.h")
-add_library(qtnats SHARED ${SOURCES} ${HEADERS})
-target_link_libraries(qtnats nats_static Qt::Core)
+add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
+
+find_package(Qt5 5.15 REQUIRED COMPONENTS Core)
+find_library(nats_library nats REQUIRED)
+
+target_link_libraries(${PROJECT_NAME} ${nats_library} Qt::Core)
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/src)
 
 # this has no effect on Windows due to https://gitlab.kitware.com/cmake/cmake/-/issues/19618
-set_target_properties(qtnats PROPERTIES VERSION 0.1.0 SOVERSION 0.1)
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION})
 
-GENERATE_EXPORT_HEADER(qtnats)
+include(GenerateExportHeader)
+GENERATE_EXPORT_HEADER(${PROJECT_NAME})
+
 
 # ------------- unit tests ----------------------
-add_executable(test_core test/test_core.cpp)
-add_test(NAME test_core COMMAND test_core)
-target_link_libraries(test_core PRIVATE qtnats Qt::Test)
+if (BUILD_TESTING)
+    enable_testing()
 
-add_executable(test_jetstream test/test_jetstream.cpp)
-add_test(NAME test_jetstream COMMAND test_jetstream)
-target_link_libraries(test_jetstream PRIVATE qtnats Qt::Test)
+    add_executable(test_core test/test_core.cpp)
+    add_test(NAME test_core COMMAND test_core)
+    target_link_libraries(test_core PRIVATE qtnats Qt::Test)
 
-if(BUILD_QMLNATS)
-    if(${QT_VERSION_MAJOR} EQUAL 6)
+    add_executable(test_jetstream test/test_jetstream.cpp)
+    add_test(NAME test_jetstream COMMAND test_jetstream)
+    target_link_libraries(test_jetstream PRIVATE qtnats Qt::Test)
+endif()
+
+if (BUILD_QMLNATS)
+    if (${QT_VERSION_MAJOR} EQUAL 6)
         add_subdirectory(qml)
     else()
         message(FATAL_ERROR "NATS QML is supported only with Qt6")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 find_package(Qt5 5.15 REQUIRED COMPONENTS Core)
 find_library(nats_library nats REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} ${nats_library} Qt::Core)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${nats_library} Qt::Core)
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/src)
 
 # this has no effect on Windows due to https://gitlab.kitware.com/cmake/cmake/-/issues/19618

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,11 @@ file(GLOB HEADERS "src/*.h")
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 
 find_package(Qt5 5.15 REQUIRED COMPONENTS Core)
-find_library(nats_library nats REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${nats_library} Qt::Core)
+find_library(nats_library nats REQUIRED)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${nats_library})
+
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/src)
 
 # this has no effect on Windows due to https://gitlab.kitware.com/cmake/cmake/-/issues/19618

--- a/src/qtnats.cpp
+++ b/src/qtnats.cpp
@@ -252,10 +252,6 @@ void Client::connectToServer(const Options& opts)
     natsOptions_SetDisconnectedCB(nats_opts, &disconnectedHandler, this);
     natsOptions_SetReconnectedCB(nats_opts, &reconnectedHandler, this);
 
-    // TODO: Auth
-    natsOptions_SetUserCredentialsFromFiles(
-        nats_opts, "/home/oleksandr-radchenko/.local/share/nats/nsc/keys/creds/MyOperator/SYS/MyUser.creds", nullptr);
-
     emit statusChanged(ConnectionStatus::Connecting);
     checkError(natsConnection_Connect(&m_conn, nats_opts));
     emit statusChanged(ConnectionStatus::Connected);

--- a/src/qtnats.h
+++ b/src/qtnats.h
@@ -1,7 +1,9 @@
 /* Copyright(c) 2021-2022 Petro Kazmirchuk https://github.com/Kazmirchuk
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.You may obtain a copy of the License at http ://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.See the License for the specific language governing permissions and  limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.You may
+obtain a copy of the License at http ://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.See the License for the specific language governing permissions and  limitations under the License.
 */
 
 #pragma once
@@ -11,19 +13,20 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #include <QObject>
 // I've received the clarification that Latin-1 should be used everywhere for strings, so QByteArray is clearer API than QString
 // https://github.com/nats-io/nats.c/issues/573
+#include <nats/nats.h>
+
 #include <QByteArray>
 #include <QFuture>
-#include <QUrl>
 #include <QMultiHash>
 #include <QSemaphore>
-
-#include <nats/nats.h>
+#include <QUrl>
 
 #include "qtnats_export.h"
 
-namespace QtNats {
+namespace QtNats
+{
 
-    QTNATS_EXPORT Q_NAMESPACE  //we need the "export" directive due to https://bugreports.qt.io/browse/QTBUG-68014
+    QTNATS_EXPORT Q_NAMESPACE // we need the "export" directive due to https://bugreports.qt.io/browse/QTBUG-68014
 
     using MessageHeaders = QMultiHash<QByteArray, QByteArray>;
 
@@ -45,11 +48,25 @@ namespace QtNats {
     class Exception : public QException
     {
     public:
-        Exception(natsStatus s) : errorCode(s) {}
+        Exception(natsStatus s):
+            errorCode(s)
+        {
+        }
 
-        void raise() const override { throw* this; }
-        Exception* clone() const override { return new Exception(*this); }
-        const char* what() const noexcept override { return natsStatus_GetText(errorCode); }
+        void raise() const override
+        {
+            throw *this;
+        }
+
+        Exception* clone() const override
+        {
+            return new Exception(*this);
+        }
+
+        const char* what() const noexcept override
+        {
+            return natsStatus_GetText(errorCode);
+        }
 
         const natsStatus errorCode;
     };
@@ -57,17 +74,36 @@ namespace QtNats {
     class JetStreamException : public Exception
     {
     public:
-        JetStreamException(natsStatus s, jsErrCode js) : Exception(s), jsError(js), errorText(initText(js)) {}
-        void raise() const override { throw* this; }
-        JetStreamException* clone() const override { return new JetStreamException(*this); }
-        const char* what() const noexcept override { return errorText.constData(); }
+        JetStreamException(natsStatus s, jsErrCode js):
+            Exception(s),
+            jsError(js),
+            errorText(initText(js))
+        {
+        }
+
+        void raise() const override
+        {
+            throw *this;
+        }
+
+        JetStreamException* clone() const override
+        {
+            return new JetStreamException(*this);
+        }
+
+        const char* what() const noexcept override
+        {
+            return errorText.constData();
+        }
 
         const jsErrCode jsError;
 
     private:
-        QByteArray initText(jsErrCode js) {
+        QByteArray initText(jsErrCode js)
+        {
             return QString("%1: %2").arg(Exception::what()).arg(js).toLatin1();
         }
+
         const QByteArray errorText;
     };
 
@@ -77,7 +113,7 @@ namespace QtNats {
         QByteArray user;
         QByteArray password;
         QByteArray token;
-        bool randomize = true; //NB! reverted option
+        bool randomize = true; // NB! reverted option
         std::optional<qint64> timeout;
         QByteArray name;
         bool secure = false;
@@ -91,24 +127,35 @@ namespace QtNats {
         std::optional<qint64> reconnectWait;
         std::optional<int> reconnectBufferSize;
         std::optional<int> maxPendingMessages;
-        bool echo = true; //NB! reverted option
+        bool echo = true; // NB! reverted option
 
         Options() = default;
     };
 
     struct QTNATS_EXPORT Message
     {
-        Message() {}
-        Message(const QByteArray& in_subject, const QByteArray& in_data) : subject(in_subject), data(in_data) {}
+        Message()
+        {
+        }
+
+        Message(const QByteArray& in_subject, const QByteArray& in_data):
+            subject(in_subject),
+            data(in_data)
+        {
+        }
+
         explicit Message(natsMsg* cmsg) noexcept;
-        bool isIncoming() const { return bool(m_natsMsg); }
+
+        bool isIncoming() const
+        {
+            return bool(m_natsMsg);
+        }
 
         // JetStream acknowledgments
         void ack();
-        void nack(qint64 delay = -1); //ms
+        void nack(qint64 delay = -1); // ms
         void inProgress();
         void terminate();
-
 
         QByteArray subject;
         QByteArray reply;
@@ -116,14 +163,14 @@ namespace QtNats {
         // NB! 1. headers are case-sensitive
         // 2. cnats does NOT preserve the order of headers
         MessageHeaders headers;
-        
+
     private:
         std::shared_ptr<natsMsg> m_natsMsg;
     };
 
     class Subscription;
     class JetStream;
-    
+
     struct JsOptions
     {
         // QString prefix = "$JS.API"; don't think it's a good idea to change this?
@@ -135,17 +182,17 @@ namespace QtNats {
     {
         Q_OBJECT
         Q_DISABLE_COPY(Client)
-        
+
     public:
         explicit Client(QObject* parent = nullptr);
         ~Client() noexcept override;
         Client(Client&&) = delete;
         Client& operator=(Client&&) = delete;
-        
+
         void connectToServer(const Options& opts);
         void connectToServer(const QUrl& address);
         void close() noexcept;
-        
+
         void publish(const Message& msg);
 
         Message request(const Message& msg, qint64 timeout = 2000);
@@ -154,8 +201,8 @@ namespace QtNats {
         Subscription* subscribe(const QByteArray& subject);
         Subscription* subscribe(const QByteArray& subject, const QByteArray& queueGroup);
 
-        bool ping(qint64 timeout = 10000) noexcept; //ms
-        
+        bool ping(qint64 timeout = 10000) noexcept; // ms
+
         QUrl currentServer() const;
         ConnectionStatus status() const;
         QString errorString() const;
@@ -164,7 +211,10 @@ namespace QtNats {
 
         JetStream* jetStream(const JsOptions& options = JsOptions());
 
-        natsConnection* getNatsConnection() const { return m_conn; }
+        natsConnection* getNatsConnection() const
+        {
+            return m_conn;
+        }
 
     signals:
         void errorOccurred(natsStatus error, const QString& text);
@@ -176,7 +226,7 @@ namespace QtNats {
 
         static void closedConnectionHandler(natsConnection* nc, void* closure);
     };
-    
+
     class QTNATS_EXPORT Subscription : public QObject
     {
         Q_OBJECT
@@ -191,7 +241,10 @@ namespace QtNats {
         void received(const Message& message);
 
     private:
-        Subscription(QObject* parent) : QObject(parent) {}
+        Subscription(QObject* parent):
+            QObject(parent)
+        {
+        }
 
         natsSubscription* m_sub = nullptr;
         friend class Client;
@@ -232,7 +285,10 @@ namespace QtNats {
         QList<Message> fetch(int batch = 1, qint64 timeout = 5000);
 
     private:
-        PullSubscription(QObject* parent) : QObject(parent) {}
+        PullSubscription(QObject* parent):
+            QObject(parent)
+        {
+        }
 
         natsSubscription* m_sub = nullptr;
         friend class JetStream;
@@ -258,23 +314,28 @@ namespace QtNats {
         Subscription* subscribe(const QByteArray& subject, const QByteArray& stream, const QByteArray& consumer);
         PullSubscription* pullSubscribe(const QByteArray& subject, const QByteArray& stream, const QByteArray& consumer);
 
-        jsCtx* getJsContext() const { return m_jsCtx; }
-        
+        jsCtx* getJsContext() const
+        {
+            return m_jsCtx;
+        }
+
     signals:
         void errorOccurred(natsStatus error, jsErrCode jsErr, const QString& text, const Message& msg);
 
     private:
-        JetStream(QObject* parent) : QObject(parent) {}
+        JetStream(QObject* parent):
+            QObject(parent)
+        {
+        }
 
         jsCtx* m_jsCtx = nullptr;
-        
+
         JsPublishAck doPublish(const Message& msg, jsPubOptions* opts);
         void doAsyncPublish(const Message& msg, jsPubOptions* opts);
 
         friend class Client;
     };
 
-    
-}
+} // namespace QtNats
 
 Q_DECLARE_METATYPE(QtNats::Message)

--- a/src/qtnats.h
+++ b/src/qtnats.h
@@ -134,9 +134,7 @@ namespace QtNats
 
     struct QTNATS_EXPORT Message
     {
-        Message()
-        {
-        }
+        Message() = default;
 
         Message(const QByteArray& in_subject, const QByteArray& in_data):
             subject(in_subject),
@@ -148,7 +146,7 @@ namespace QtNats
 
         bool isIncoming() const
         {
-            return bool(m_natsMsg);
+            return m_natsMsg != nullptr;
         }
 
         // JetStream acknowledgments

--- a/src/qtnats.h
+++ b/src/qtnats.h
@@ -17,7 +17,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #include <QMultiHash>
 #include <QSemaphore>
 
-#include <nats.h>
+#include <nats/nats.h>
 
 #include "qtnats_export.h"
 
@@ -78,22 +78,22 @@ namespace QtNats {
         QByteArray password;
         QByteArray token;
         bool randomize = true; //NB! reverted option
-        qint64 timeout;
+        std::optional<qint64> timeout;
         QByteArray name;
         bool secure = false;
         bool verbose = false;
         bool pedantic = false;
-        qint64 pingInterval;
-        int maxPingsOut;
-        int ioBufferSize;
+        std::optional<qint64> pingInterval;
+        std::optional<int> maxPingsOut;
+        std::optional<int> ioBufferSize;
         bool allowReconnect = true;
-        int maxReconnect;
-        qint64 reconnectWait;
-        int reconnectBufferSize;
-        int maxPendingMessages;
+        std::optional<int> maxReconnect;
+        std::optional<qint64> reconnectWait;
+        std::optional<int> reconnectBufferSize;
+        std::optional<int> maxPendingMessages;
         bool echo = true; //NB! reverted option
 
-        Options();
+        Options() = default;
     };
 
     struct QTNATS_EXPORT Message

--- a/src/qtnats_p.h
+++ b/src/qtnats_p.h
@@ -1,20 +1,22 @@
 /* Copyright(c) 2022 Petro Kazmirchuk https://github.com/Kazmirchuk
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.You may obtain a copy of the License at http ://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.See the License for the specific language governing permissions and  limitations under the License.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.You may
+obtain a copy of the License at http ://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.See the License for the specific language governing permissions and  limitations under the License.
 */
 
 #pragma once
 
 #include "qtnats.h"
 
-namespace QtNats {
+namespace QtNats
+{
+    void checkError(natsStatus s);
 
-	void checkError(natsStatus s);
+    using NatsMsgPtr = std::unique_ptr<natsMsg, decltype(&natsMsg_Destroy)>;
 
-	using NatsMsgPtr = std::unique_ptr<natsMsg, decltype(&natsMsg_Destroy)>;
+    NatsMsgPtr toNatsMsg(const Message& msg, const char* reply = nullptr);
 
-	NatsMsgPtr toNatsMsg(const Message& msg, const char* reply = nullptr);
-
-	void subscriptionCallback(natsConnection* nc, natsSubscription* sub, natsMsg* msg, void* closure);
-}
+    void subscriptionCallback(natsConnection* nc, natsSubscription* sub, natsMsg* msg, void* closure);
+} // namespace QtNats


### PR DESCRIPTION
Some small changes here (1 commit is clang-format, can be excluded from review)
That library is good to be used as-is, but we might need to JWT token support (or some other security related features) in the future. All of it is supported by CNats library, so it would be a simple matter of extending the interface for this library